### PR TITLE
♻️ 코드 리팩토링 : AWS S3 로직 리팩토링 - 인터페이스 기반 구조 개선

### DIFF
--- a/src/main/java/com/realworld/application/file/dto/FileMetaData.java
+++ b/src/main/java/com/realworld/application/file/dto/FileMetaData.java
@@ -1,0 +1,47 @@
+package com.realworld.application.file.dto;
+
+import com.realworld.common.holder.uuid.UUIDHolder;
+import com.realworld.infrastructure.image.ResizedImage;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+public class FileMetaData {
+
+    private final String targetDirectory;
+    private final String name;
+    private final String contentType;
+    private final long size;
+
+    @Builder
+    private FileMetaData(String targetDirectory, String name, long size, String contentType) {
+        this.targetDirectory = targetDirectory;
+        this.name = name;
+        this.size = size;
+        this.contentType = contentType;
+    }
+
+    public static FileMetaData create(String targetDirectory, UUIDHolder uuidHolder, ResizedImage resizedImage) {
+        return FileMetaData.builder()
+                .targetDirectory(targetDirectory)
+                .name(uuidHolder.generate() + "." + resizedImage.getExtension())
+                .contentType("image/" + resizedImage.getExtension())
+                .size(resizedImage.getSize())
+                .build();
+    }
+
+    public static FileMetaData create(MultipartFile file, String targetDirectory, UUIDHolder uuidHolder) {
+        String originalFilename = FilenameUtils.getName(file.getOriginalFilename());
+        String extension = FilenameUtils.getExtension(originalFilename);
+
+        return FileMetaData.builder()
+                .targetDirectory(targetDirectory)
+                .name(uuidHolder.generate() + "." + extension)
+                .contentType("image/" + extension)
+                .size(file.getSize())
+                .build();
+    }
+
+}

--- a/src/main/java/com/realworld/application/file/port/FileStorage.java
+++ b/src/main/java/com/realworld/application/file/port/FileStorage.java
@@ -1,0 +1,15 @@
+package com.realworld.application.file.port;
+
+import com.realworld.application.file.dto.FileMetaData;
+
+import java.io.InputStream;
+
+public interface FileStorage {
+
+    String save(FileMetaData metaData, InputStream stream);
+
+    String move(String sourcePath, String targetDirectory);
+
+    void delete(String sourcePath);
+
+}

--- a/src/main/java/com/realworld/common/holder/uuid/UUIDHolder.java
+++ b/src/main/java/com/realworld/common/holder/uuid/UUIDHolder.java
@@ -1,0 +1,8 @@
+package com.realworld.common.holder.uuid;
+
+@FunctionalInterface
+public interface UUIDHolder {
+
+    String generate();
+
+}

--- a/src/main/java/com/realworld/common/holder/uuid/UUIDHolderImpl.java
+++ b/src/main/java/com/realworld/common/holder/uuid/UUIDHolderImpl.java
@@ -1,0 +1,12 @@
+package com.realworld.common.holder.uuid;
+
+import java.util.UUID;
+
+public class UUIDHolderImpl implements UUIDHolder {
+
+    @Override
+    public String generate() {
+        return UUID.randomUUID().toString();
+    }
+
+}

--- a/src/main/java/com/realworld/infrastructure/cloud/CloudFileStorage.java
+++ b/src/main/java/com/realworld/infrastructure/cloud/CloudFileStorage.java
@@ -1,0 +1,32 @@
+package com.realworld.infrastructure.cloud;
+
+import com.realworld.application.file.port.FileStorage;
+import com.realworld.application.file.dto.FileMetaData;
+import com.realworld.infrastructure.cloud.aws.AwsS3Handler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+
+@Component
+@RequiredArgsConstructor
+public class CloudFileStorage implements FileStorage {
+
+    private final AwsS3Handler awsS3Handler;
+
+    @Override
+    public String save(FileMetaData metaData, InputStream stream) {
+        return awsS3Handler.save(metaData, stream);
+    }
+
+    @Override
+    public String move(String sourcePath, String targetDirectory) {
+        return awsS3Handler.move(sourcePath, targetDirectory);
+    }
+
+    @Override
+    public void delete(String sourcePath) {
+        awsS3Handler.delete(sourcePath);
+    }
+
+}

--- a/src/main/java/com/realworld/infrastructure/cloud/aws/AwsS3Handler.java
+++ b/src/main/java/com/realworld/infrastructure/cloud/aws/AwsS3Handler.java
@@ -1,0 +1,17 @@
+package com.realworld.infrastructure.cloud.aws;
+
+import com.realworld.application.file.dto.FileMetaData;
+
+import java.io.InputStream;
+
+public interface AwsS3Handler {
+
+    String save(FileMetaData metaData, InputStream stream);
+
+    boolean isFileExist(String sourcePath, String fileName);
+
+    String move(String sourcePath, String targetDirectory);
+
+    void delete(String sourcePath);
+
+}

--- a/src/main/java/com/realworld/infrastructure/cloud/aws/AwsS3HandlerImpl.java
+++ b/src/main/java/com/realworld/infrastructure/cloud/aws/AwsS3HandlerImpl.java
@@ -1,0 +1,103 @@
+package com.realworld.infrastructure.cloud.aws;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.realworld.application.file.dto.FileMetaData;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import java.io.File;
+import java.io.InputStream;
+
+@Validated
+@Component
+public class AwsS3HandlerImpl implements AwsS3Handler {
+
+    private final String cloudFrontBasePath;
+    private final String bucketName;
+    private final AmazonS3 s3Client;
+
+    public AwsS3HandlerImpl(
+            @NotNull @Value("${cloud.aws.cloudfront}") String cloudFrontBasePath,
+            @NotNull @Value("${cloud.aws.s3.bucket}") String bucketName,
+            AmazonS3 s3Client
+
+    ) {
+        this.cloudFrontBasePath = cloudFrontBasePath;
+        this.bucketName = bucketName;
+        this.s3Client = s3Client;
+    }
+
+    @Override
+    public String save(FileMetaData metaData, InputStream stream) {
+        String bucketPath = bucketName + File.separator + metaData.getTargetDirectory();
+
+        s3Client.putObject(
+                new PutObjectRequest(
+                        bucketPath,
+                        metaData.getName(),
+                        stream,
+                        getObjectMetadata(metaData.getContentType(), metaData.getSize())
+                ).withCannedAcl(CannedAccessControlList.Private)
+        );
+
+        return cloudFrontBasePath + metaData.getTargetDirectory() + File.separator + metaData.getName();
+    }
+
+    private ObjectMetadata getObjectMetadata(String contentType, long size) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(contentType);
+        metadata.setContentLength(size);
+        return metadata;
+    }
+
+    @Override
+    public boolean isFileExist(String sourcePath, String fileName) {
+        return s3Client.doesObjectExist(sourcePath, fileName);
+    }
+
+    @Override
+    public String move(String sourcePath, String targetDirectory) {
+        String fileName = extractFileName(sourcePath);
+        String sourceDirectory = extractDirectoryName(sourcePath);
+
+        String sourceFullPath = bucketName + File.separator + sourceDirectory;
+        String targetFullPath = bucketName + File.separator + targetDirectory;
+
+        if (!isFileExist(sourceFullPath, fileName)) {
+            // Rest API Exception 발생 !!!
+        }
+
+        s3Client.copyObject(sourceFullPath, fileName, targetFullPath, fileName);
+
+        return cloudFrontBasePath + targetDirectory + File.separator + fileName;
+    }
+
+    @Override
+    public void delete(String sourcePath) {
+        String fileName = extractFileName(sourcePath);
+        String sourceDirectory = extractDirectoryName(sourcePath);
+        String targetFullPath = bucketName + File.separator + sourceDirectory;
+
+        if (isFileExist(targetFullPath, fileName)) {
+            s3Client.deleteObject(targetFullPath, fileName);
+        } else {
+            // Rest API Exception 발생!
+        }
+    }
+
+    private String extractDirectoryName(String sourcePath) {
+        int nextPathSlashIndex = sourcePath.indexOf('/', cloudFrontBasePath.length());
+        return sourcePath.substring(cloudFrontBasePath.length(), nextPathSlashIndex);
+    }
+
+    private String extractFileName(String sourcePath) {
+        int lastSlashIndex = sourcePath.lastIndexOf('/');
+        return sourcePath.substring(lastSlashIndex + 1);
+    }
+
+}

--- a/src/main/java/com/realworld/v1/infra/aws/AwsServiceV1.java
+++ b/src/main/java/com/realworld/v1/infra/aws/AwsServiceV1.java
@@ -14,7 +14,7 @@ import java.io.InputStream;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class AwsService {
+public class AwsServiceV1 {
     private final AmazonS3 amazonS3;
 
     @Value("${cloud.aws.s3.bucket}")

--- a/src/test/java/com/realworld/infrastructure/cloud/aws/AwsS3HandlerImplTest.java
+++ b/src/test/java/com/realworld/infrastructure/cloud/aws/AwsS3HandlerImplTest.java
@@ -1,0 +1,108 @@
+/*
+package com.realworld.infrastructure.cloud.aws;
+
+import com.realworld.application.file.dto.FileMetaData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("local")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AwsS3HandlerImplTest {
+
+    private static final String BUCKET_NAME = "photocardsite";
+    private static final String TEMPORARY_DIRECTORY = "temporary";
+    private static final String TEST_DIRECTORY = "test";
+    private static final String TEST_IMAGE_PATH = "src/test/resources/image/test-image.jpeg";
+
+    private File testFile;
+    private FileMetaData fileMetaData;
+    private InputStream inputStream;
+    private String fileUrl;
+
+    @Autowired
+    private AwsS3Handler awsS3Handler;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        testFile = new File(TEST_IMAGE_PATH);
+        inputStream = new FileInputStream(testFile);
+
+        fileMetaData = FileMetaData.builder()
+                .targetDirectory(TEMPORARY_DIRECTORY)
+                .name("test-image.jpeg")
+                .contentType("image/jpeg")
+                .size(testFile.length())
+                .build();
+    }
+
+    @Test
+    void AWS_S3_파일_업로드() {
+        // given
+        // when
+        fileUrl = awsS3Handler.save(fileMetaData, inputStream);
+
+        // then
+        assertThat(fileUrl).isNotNull();
+        assertThat(awsS3Handler.isFileExist(getBucketPath(TEMPORARY_DIRECTORY), fileMetaData.getName())).isTrue();
+    }
+
+    @Test
+    void AWS_S3_파일_조회() {
+        // given
+        fileUrl = awsS3Handler.save(fileMetaData, inputStream);
+
+        // when
+        Boolean result = awsS3Handler.isFileExist(getBucketPath(TEMPORARY_DIRECTORY), fileMetaData.getName());
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void AWS_S3_파일_이동() {
+        // given
+        // when
+        fileUrl = awsS3Handler.save(fileMetaData, inputStream);
+
+        // when
+        awsS3Handler.move(fileUrl, TEST_DIRECTORY);
+
+        // then
+        assertThat(awsS3Handler.isFileExist(getBucketPath(TEST_DIRECTORY), fileMetaData.getName())).isTrue();
+    }
+
+    @Test
+    void AWS_S3_파일_삭제() {
+        // given
+        fileUrl = awsS3Handler.save(fileMetaData, inputStream);
+
+        // when
+        awsS3Handler.delete(fileUrl);
+
+        // then
+        assertThat(awsS3Handler.isFileExist(getBucketPath(TEMPORARY_DIRECTORY), fileMetaData.getName())).isFalse();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (inputStream != null) {
+            inputStream.close();
+        }
+        awsS3Handler.delete(fileUrl);
+    }
+
+    private String getBucketPath(String directory) {
+        return BUCKET_NAME + "/" + directory;
+    }
+
+}
+*/


### PR DESCRIPTION
## ✨ 작업 내용

1. **AwsS3Handler 인터페이스 도입 및 AwsS3HandlerImpl 구현체 생성**  
   - `AmazonS3` 클라이언트와의 직접 통신 로직을 `AwsS3HandlerImpl`에 집중 ⚙️  
   - 추후 다른 클라우드 스토리지로 변경할 경우에도 인터페이스만 교체하면 쉽게 확장 가능

2. **CloudFront 경로와 실제 S3 버킷 경로를 명확히 구분**  
   - `cloudFrontBasePath`, `bucketName` 등을 주입(@Value) 받아 별도로 관리 🌐  
   - 파일명 추출, 디렉토리 파싱 로직을 메서드화하여 로직 가독성 향상

3. **메타데이터 생성 로직(파일 사이즈, Content-Type) 메서드 분리**  
   - `getObjectMetadata` 같은 유틸성 메서드를 별도 구현하여 유지보수 용이성 증대 🗃️

4. **S3 객체 존재 여부 검사(isFileExist), 파일 이동(move), 삭제(delete) 로직 추가/개선**  
   - **`isFileExist`**: 대상 파일이 실제로 S3에 존재하는지 확인 ✅  
   - **`move`**: 소스 경로에서 타겟 경로로 파일 이동 ↪️  
   - **`delete`**: 필요 시 파일 삭제 후 예외 처리 로직 강화(존재하지 않을 경우 예외 발생 등) ❌

5. **기존 `AwsService` 클래스에 V1 시그니처(`AwsServiceV1`)를 부여하여 더 이상 사용되지 않음을 명시**  
   - 새 구조(`AwsS3Handler`/`AwsS3HandlerImpl`)로 마이그레이션 완료 후, 기존 코드를 Deprecated 처리 ⚠️

6. **`AwsS3HandlerImplTest` 작성으로 S3 업로드, 조회, 이동, 삭제 기능 테스트**  
   - 실제 S3 연동 없이 Mock 또는 테스트 컨테이너 기반 테스트도 가능하도록 설계 🔬  
   - 테스트를 통해 각 기능이 정상 동작하는지 검증

---

## 🔄 변경 이유

- **단일 책임 원칙 준수**: 하나의 클래스(`AwsService`)에서 모든 로직을 다루던 문제를 해결  
- **확장성**: 다른 클라우드 스토리지(예: GCP, Azure)로 교체할 가능성을 고려해 인터페이스 기반으로 분리  
- **테스트 용이성**: 테스트 코드(`AwsS3HandlerImplTest`)를 작성해 업로드/조회/이동/삭제 기능을 체계적으로 검증  

---

## 📌 영향 범위

- 기존 `AwsService` → `AwsServiceV1`로 명명 변경 (Deprecated 처리)  
- 신규 `AwsS3Handler`, `AwsS3HandlerImpl` 도입  
- 메타데이터 로직, 파일 경로 처리 방식 변경  
- 테스트 코드 추가 및 리팩토링  

---

## 🔗 이슈 사항

- **#21**

---

## 📎 참고 사항

- 로컬이나 CI 환경에서 테스트 시, S3 및 CloudFront 설정이 필요할 수 있습니다.  