### PR TITLE
✅ 테스트 수정 : 파일 도메인 기능 테스트 명명 수정 및 MockFileData 구조 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,9 @@ repositories {
 dependencies {
     // QueryDSL JPA 라이브러리
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
     // java.lang.NoClassDefFoundError(javax.annotation.Generated) 발생 시 추가
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
@@ -71,7 +71,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mockito:mockito-core:3.9.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testImplementation 'com.querydsl:querydsl-jpa'
+    testImplementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 
@@ -95,8 +95,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-    // mongodb 설정 추가
+//    // mongodb 설정 추가
 //    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
     // kafka
 //    implementation 'org.springframework.kafka:spring-kafka'
 

--- a/src/main/java/com/realworld/application/file/service/FileService.java
+++ b/src/main/java/com/realworld/application/file/service/FileService.java
@@ -5,11 +5,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface FileService {
 
-    File saveResizedImage(String destinationDirectory, MultipartFile file, int width, int height);
+    File saveResizedImage(String targetDir, MultipartFile file, int width, int height);
 
-    File saveImage(String destinationDirectory, MultipartFile file);
+    File saveImage(String targetDir, MultipartFile file);
 
-    String move(String sourcePath, String destinationDirectory);
+    String move(String sourcePath, String targetDir);
 
     void delete(String sourcePath);
 

--- a/src/main/java/com/realworld/application/file/service/FileServiceImpl.java
+++ b/src/main/java/com/realworld/application/file/service/FileServiceImpl.java
@@ -26,12 +26,12 @@ public class FileServiceImpl implements FileService {
     private final FileStorage fileStorage;
 
     @Override
-    public File saveResizedImage(String destinationDirectory, MultipartFile file, int width, int height) {
+    public File saveResizedImage(String targetDir, MultipartFile file, int width, int height) {
         validateImageFileType(file);
         try (InputStream inputStream = file.getInputStream();
              ResizedImage resizedImage = imageResizer.resize(width, height, ImageIO.read(inputStream))
         ) {
-            FileMetaData metaData = FileMetaData.fromResizedImage(destinationDirectory, resizedImage, new UUIDHolderImpl());
+            FileMetaData metaData = FileMetaData.fromResizedImage(targetDir, resizedImage, new UUIDHolderImpl());
             String url = fileStorage.save(metaData, resizedImage.getInputStream());
             return File.create(metaData.getDetails(), url);
         } catch (IOException e) {
@@ -42,10 +42,10 @@ public class FileServiceImpl implements FileService {
     }
 
     @Override
-    public File saveImage(String destinationDirectory, MultipartFile file) {
+    public File saveImage(String targetDir, MultipartFile file) {
         validateImageFileType(file);
         try (InputStream inputStream = file.getInputStream()) {
-            FileMetaData metaData = FileMetaData.fromMultipartFile(destinationDirectory, file, new UUIDHolderImpl());
+            FileMetaData metaData = FileMetaData.fromMultipartFile(targetDir, file, new UUIDHolderImpl());
             String url = fileStorage.save(metaData, inputStream);
             return File.create(metaData.getDetails(), url);
         } catch (IOException e) {
@@ -61,8 +61,8 @@ public class FileServiceImpl implements FileService {
     }
 
     @Override
-    public String move(String sourcePath, String destinationDirectory) {
-        return fileStorage.move(sourcePath, destinationDirectory);
+    public String move(String sourcePath, String targetDir) {
+        return fileStorage.move(sourcePath, targetDir);
     }
 
     @Override

--- a/src/main/java/com/realworld/common/config/aws/AwsS3Config.java
+++ b/src/main/java/com/realworld/common/config/aws/AwsS3Config.java
@@ -2,20 +2,20 @@ package com.realworld.common.config.aws;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class S3Config {
+public class AwsS3Config {
 
     private final String accessKey;
     private final String secretKey;
     private final String region;
 
-    public S3Config(
+    public AwsS3Config(
             @Value("${cloud.aws.credentials.access-key}") String accessKey,
             @Value("${cloud.aws.credentials.secret-key}") String secretKey,
             @Value("${cloud.aws.region.static}") String region
@@ -26,10 +26,10 @@ public class S3Config {
     }
 
     @Bean
-    public AmazonS3Client amazonS3Client() {
+    public AmazonS3 amazonS3() {
         BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
 
-        return (AmazonS3Client) AmazonS3ClientBuilder
+        return AmazonS3ClientBuilder
                 .standard()
                 .withRegion(region)
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))

--- a/src/main/java/com/realworld/feature/file/entity/FileMetaData.java
+++ b/src/main/java/com/realworld/feature/file/entity/FileMetaData.java
@@ -24,8 +24,8 @@ public class FileMetaData {
         this.details = details;
     }
 
-    public static FileMetaData fromResizedImage(String destinationDirectory, ResizedImage resizedImage, UUIDHolder uuidHolder) {
-        notNullParameters(resizedImage, destinationDirectory, uuidHolder);
+    public static FileMetaData fromResizedImage(String targetDir, ResizedImage resizedImage, UUIDHolder uuidHolder) {
+        notNullParameters(resizedImage, targetDir, uuidHolder);
 
         String generatedName = FileFormat.IMAGE.generateFileName(uuidHolder.generate(), resizedImage.getImageFormat());
         String generatedContentType = FileFormat.IMAGE.generateContentType(resizedImage.getImageFormat());
@@ -34,19 +34,19 @@ public class FileMetaData {
         FileDetails details = FileDetails.of(generatedName, generatedContentType, size);
 
         return FileMetaData.builder()
-                .directory(destinationDirectory)
+                .directory(targetDir)
                 .details(details)
                 .build();
     }
 
-    private static void notNullParameters(ResizedImage resizedImage, String destinationDirectory, UUIDHolder uuidHolder) {
-        if (Objects.isNull(destinationDirectory) || Objects.isNull(uuidHolder) || Objects.isNull(resizedImage) || resizedImage.getSize() <= 0) {
+    private static void notNullParameters(ResizedImage resizedImage, String targetDir, UUIDHolder uuidHolder) {
+        if (Objects.isNull(targetDir) || Objects.isNull(uuidHolder) || Objects.isNull(resizedImage) || resizedImage.getSize() <= 0) {
             throw new CustomFileExceptionHandler(ErrorCode.FILE_PROCESSING_ERROR);
         }
     }
 
-    public static FileMetaData fromMultipartFile(String destinationDirectory, MultipartFile file, UUIDHolder uuidHolder) {
-        notNullParameters(file, destinationDirectory, uuidHolder);
+    public static FileMetaData fromMultipartFile(String targetDir, MultipartFile file, UUIDHolder uuidHolder) {
+        notNullParameters(file, targetDir, uuidHolder);
 
         String originalFilename = FilenameUtils.getName(file.getOriginalFilename());
         String extension = FilenameUtils.getExtension(originalFilename);
@@ -57,13 +57,13 @@ public class FileMetaData {
         FileDetails details = FileDetails.of(generatedName, generatedContentType, size);
 
         return FileMetaData.builder()
-                .directory(destinationDirectory)
+                .directory(targetDir)
                 .details(details)
                 .build();
     }
 
-    private static void notNullParameters(MultipartFile file, String destinationDirectory, UUIDHolder uuidHolder) {
-        if (Objects.isNull(destinationDirectory) || Objects.isNull(uuidHolder) || Objects.isNull(file) || file.getSize() <= 0) {
+    private static void notNullParameters(MultipartFile file, String targetDir, UUIDHolder uuidHolder) {
+        if (Objects.isNull(targetDir) || Objects.isNull(uuidHolder) || Objects.isNull(file) || file.getSize() <= 0) {
             throw new CustomFileExceptionHandler(ErrorCode.FILE_PROCESSING_ERROR);
         }
     }

--- a/src/main/java/com/realworld/web/file/controller/FileController.java
+++ b/src/main/java/com/realworld/web/file/controller/FileController.java
@@ -20,7 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 @Tag(
@@ -28,7 +28,7 @@ import java.util.List;
         description = "파일 리사이즈, 업로드, 이동 및 삭제를 위한 API"
 )
 @RestController
-@RequestMapping("/files")
+@RequestMapping("/V2/files")
 @RequiredArgsConstructor
 public class FileController {
 
@@ -41,7 +41,8 @@ public class FileController {
     @ExceptionResponseAnnotations({
             ErrorCode.UNSUPPORTED_FILE_IMAGE_TYPE_ERROR,
             ErrorCode.FILE_PROCESSING_ERROR,
-            ErrorCode.FILE_IMAGE_RESIZE_ERROR
+            ErrorCode.FILE_IMAGE_RESIZE_ERROR,
+            ErrorCode.FILE_IMAGE_PROCESSING_ERROR
     })
     @PostMapping(
             value = "/upload/images/resize",
@@ -49,23 +50,24 @@ public class FileController {
     )
     public ResponseEntity<SuccessResponse<FileResponses>> uploadResizedImage(
             @RequestPart("files") @Parameter(description = "업로드할 이미지 파일들 (다중 파일 가능)") MultipartFile[] files,
-            @RequestParam(name = "destination_directory", required = false, defaultValue = "temporary") @Parameter(description = "저장할 대상 디렉터리 경로") String destinationDirectory,
+            @RequestParam(name = "target_directory", required = false, defaultValue = "temporary") @Parameter(description = "저장할 대상 디렉터리 경로") String targetDir,
             @RequestParam(defaultValue = "200") @Parameter(description = "리사이즈할 이미지의 너비") int width,
             @RequestParam(defaultValue = "200") @Parameter(description = "리사이즈할 이미지의 높이") int height
     ) {
-        List<FileResponse> fileResponses = Arrays.stream(files)
-                .map(file -> FileResponse.from(
-                        fileService.saveResizedImage(
-                                destinationDirectory,
-                                file,
-                                width,
-                                height
-                        )
-                ))
-                .toList();
+        List<FileResponse> fileResponses = new ArrayList<>(files.length);
+        for (MultipartFile file : files) {
+            FileResponse response = FileResponse.from(
+                    fileService.saveResizedImage(
+                            targetDir,
+                            file,
+                            width,
+                            height
+                    )
+            );
+            fileResponses.add(response);
+        }
 
         FileResponses responses = FileResponses.of(fileResponses);
-
         SuccessResponse<FileResponses> successResponse = new SuccessResponse<>(
                 responses,
                 SUCCESS_STATUS,
@@ -80,25 +82,21 @@ public class FileController {
     @ExceptionResponseAnnotations({
             ErrorCode.UNSUPPORTED_FILE_IMAGE_TYPE_ERROR,
             ErrorCode.FILE_PROCESSING_ERROR,
-            ErrorCode.FILE_IMAGE_RESIZE_ERROR
     })
     @PostMapping(value = "/upload/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SuccessResponse<FileResponses>> uploadImage(
             @RequestPart @Parameter(description = "업로드할 이미지 파일들 (다중 파일 가능)") MultipartFile[] files,
-            @RequestParam(name = "destination_directory", required = false, defaultValue = "temporary")
-            @Parameter(description = "저장할 대상 디렉터리 경로 (기본값: 임시 디렉터리)") String destinationDirectory
+            @RequestParam(name = "target_directory", required = false, defaultValue = "temporary") @Parameter(description = "저장할 대상 디렉터리 경로 (기본값: 임시 디렉터리)") String targetDir
     ) {
-        List<FileResponse> fileResponses = Arrays.stream(files)
-                .map(file -> FileResponse.from(
-                        fileService.saveImage(
-                                destinationDirectory,
-                                file
-                        )
-                ))
-                .toList();
+        List<FileResponse> fileResponses = new ArrayList<>(files.length);
+        for (MultipartFile file : files) {
+            FileResponse response = FileResponse.from(
+                    fileService.saveImage(targetDir, file)
+            );
+            fileResponses.add(response);
+        }
 
         FileResponses responses = FileResponses.of(fileResponses);
-
         SuccessResponse<FileResponses> successResponse = new SuccessResponse<>(
                 responses,
                 SUCCESS_STATUS,
@@ -113,12 +111,13 @@ public class FileController {
     @ExceptionResponseAnnotations(ErrorCode.FILE_NOT_FOUND_ERROR)
     @PatchMapping("/move")
     public ResponseEntity<SuccessResponse<FileUrlResponses>> move(@RequestBody final FileMoveRequest request) {
-        List<String> movedUrls = request.getUrls().stream()
-                .map(url -> fileService.move(url, request.getDirectory()))
-                .toList();
+        List<String> movedUrls = new ArrayList<>(request.getUrls().size());
+        for (String url : request.getUrls()) {
+            fileService.move(url, request.getDirectory());
+            movedUrls.add(url);
+        }
 
         FileUrlResponses responses = FileUrlResponses.of(movedUrls);
-
         SuccessResponse<FileUrlResponses> successResponse = new SuccessResponse<>(
                 responses,
                 SUCCESS_STATUS,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,16 +2,17 @@ server:
   port: 8080
   servlet:
     context-path: /api
+
 spring:
   jpa:
     show-sql: true
     hibernate:
       ddl-auto: update
   profiles:
-    active: local # default
+    active: dev # default
     group:
-      local: "local, datasource, jpa, mail, logging, jasypt"
       dev: "dev, datasource, jpa, mail, logging, jasypt"
+      local: "local, datasource, jpa, mail, logging, jasypt"
 
 management:
   health:
@@ -32,4 +33,3 @@ springdoc:
     operations-sorter: method
     disable-swagger-default-url: true
     display-request-duration: true
-

--- a/src/test/java/com/realworld/common/localstack/TestLocalStackConfig.java
+++ b/src/test/java/com/realworld/common/localstack/TestLocalStackConfig.java
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.NotNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.validation.annotation.Validated;
 
@@ -40,15 +39,11 @@ public class TestLocalStackConfig {
     }
 
     @Bean
-    @Primary
     public AmazonS3 amazonS3() {
-        AwsClientBuilder.EndpointConfiguration endpointConfiguration = new AwsClientBuilder
-                .EndpointConfiguration(endpoint, region);
-
         AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
 
         AmazonS3 amazonS3 = AmazonS3ClientBuilder.standard()
-                .withEndpointConfiguration(endpointConfiguration)
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
                 .withPathStyleAccessEnabled(true)
                 .build();

--- a/src/test/java/com/realworld/feature/file/domain/FileDetailsTest.java
+++ b/src/test/java/com/realworld/feature/file/domain/FileDetailsTest.java
@@ -14,8 +14,8 @@ class FileDetailsTest {
     @Test
     void 파일_상세_정보를_생성한다() {
         // Given
-        String name = MockFileData.TEST_FILE_NAME;
-        String contentType = MockFileData.TEST_CONTENT_TYPE;
+        String name = MockFileData.FILE_NAME;
+        String contentType = MockFileData.FILE_CONTENT_TYPE;
         long size = 1024L;
 
         // When
@@ -32,7 +32,7 @@ class FileDetailsTest {
     void 파일_이름이_NULL이면_예외를_던진다() {
         // Given
         String name = null;
-        String contentType = MockFileData.TEST_CONTENT_TYPE;
+        String contentType = MockFileData.FILE_CONTENT_TYPE;
         long size = 1024L;
 
         // When & Then
@@ -46,7 +46,7 @@ class FileDetailsTest {
     @Test
     void 콘텐츠_타입이_NULL이면_예외를_던진다() {
         // Given
-        String name = MockFileData.TEST_FILE_NAME;
+        String name = MockFileData.FILE_NAME;
         String contentType = null;
         long size = 1024L;
 
@@ -61,8 +61,8 @@ class FileDetailsTest {
     @Test
     void 파일_사이즈가_0이면_예외를_던진다() {
         // Given
-        String name = MockFileData.TEST_FILE_NAME;
-        String contentType = MockFileData.TEST_CONTENT_TYPE;
+        String name = MockFileData.FILE_NAME;
+        String contentType = MockFileData.FILE_CONTENT_TYPE;
         long size = 0L;
 
         // When & Then

--- a/src/test/java/com/realworld/feature/file/domain/FileMetaDataTest.java
+++ b/src/test/java/com/realworld/feature/file/domain/FileMetaDataTest.java
@@ -3,6 +3,7 @@ package com.realworld.feature.file.domain;
 import com.realworld.common.exception.custom.CustomFileExceptionHandler;
 import com.realworld.common.holder.uuid.UUIDHolder;
 import com.realworld.common.response.code.ErrorCode;
+import com.realworld.common.type.file.FileFormat;
 import com.realworld.feature.file.entity.FileMetaData;
 import com.realworld.feature.file.mock.MockFileData;
 import com.realworld.infrastructure.image.ResizedImage;
@@ -10,46 +11,49 @@ import org.apache.commons.io.FilenameUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockMultipartFile;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class FileMetaDataTest {
+
+    private static final String TEST_DIRECTORY = "temporary";
+    private static final String TEST_EXTENSION = "jpeg";
+    private static final String TEST_UUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
+    private static final String TEST_FILE_NAME = TEST_UUID + FileFormat.IMAGE.getExtensionSeparator() + TEST_EXTENSION;
 
     @Test
     void 리사이즈된_이미지로_파일_메타데이터를_생성한다() {
         // Given
-        String destinationDirectory = MockFileData.TEST_DIRECTORY;
+        String targetDir = TEST_DIRECTORY;
         ResizedImage resizedImage = mock(ResizedImage.class);
-        when(resizedImage.getImageFormat()).thenReturn(MockFileData.TEST_EXTENSION);
+        when(resizedImage.getImageFormat()).thenReturn(TEST_EXTENSION);
         when(resizedImage.getSize()).thenReturn(MockFileData.FILE_SIZE);
 
         // When
         FileMetaData result = FileMetaData.fromResizedImage(
-                destinationDirectory,
+                targetDir,
                 resizedImage,
-                () -> MockFileData.TEST_UUID
+                () -> TEST_UUID
         );
 
         // Then
         assertThat(result).isNotNull();
-        assertThat(result.getDirectory()).isEqualTo(destinationDirectory);
+        assertThat(result.getDirectory()).isEqualTo(targetDir);
         assertThat(result.getDetails()).isNotNull();
-        assertThat(result.getDetails().getName()).isEqualTo(MockFileData.TEST_FILE_NAME);
-        assertThat(result.getDetails().getContentType()).isEqualTo(MockFileData.TEST_CONTENT_TYPE);
+        assertThat(result.getDetails().getName()).isEqualTo(TEST_FILE_NAME);
+        assertThat(result.getDetails().getContentType()).isEqualTo(MockFileData.FILE_CONTENT_TYPE);
         assertThat(result.getDetails().getSize()).isEqualTo(MockFileData.FILE_SIZE);
     }
 
     @Test
     void 리사이즈된_이미지가_NULL이면_예외를_던진다() {
         // Given
-        String destinationDirectory = MockFileData.TEST_DIRECTORY;
-        UUIDHolder uuidHolder = () -> MockFileData.TEST_UUID;
+        String targetDir = TEST_DIRECTORY;
+        UUIDHolder uuidHolder = () -> TEST_UUID;
         ResizedImage invalidImage = null;
 
         // When & Then
-        assertThatThrownBy(() -> FileMetaData.fromResizedImage(destinationDirectory, invalidImage, uuidHolder))
+        assertThatThrownBy(() -> FileMetaData.fromResizedImage(targetDir, invalidImage, uuidHolder))
                 .isInstanceOf(CustomFileExceptionHandler.class)
                 .hasMessageContaining(
                         ErrorCode.FILE_PROCESSING_ERROR.getMessage()
@@ -59,14 +63,14 @@ class FileMetaDataTest {
     @Test
     void 저장_디렉토리가_NULL이면_리사이즈된_이미지로_예외를_던진다() {
         // Given
-        String emptyDirectory = null;
-        UUIDHolder uuidHolder = () -> MockFileData.TEST_UUID;
+        String emptyDir = null;
+        UUIDHolder uuidHolder = () -> TEST_UUID;
         ResizedImage resizedImage = mock(ResizedImage.class);
-        when(resizedImage.getImageFormat()).thenReturn(MockFileData.TEST_EXTENSION);
+        when(resizedImage.getImageFormat()).thenReturn(TEST_EXTENSION);
         when(resizedImage.getSize()).thenReturn(MockFileData.FILE_SIZE);
 
         // when
-        assertThatThrownBy(() -> FileMetaData.fromResizedImage(emptyDirectory, resizedImage, uuidHolder))
+        assertThatThrownBy(() -> FileMetaData.fromResizedImage(emptyDir, resizedImage, uuidHolder))
                 .isInstanceOf(CustomFileExceptionHandler.class)
                 .hasMessageContaining(
                         ErrorCode.FILE_PROCESSING_ERROR.getMessage()
@@ -76,14 +80,14 @@ class FileMetaDataTest {
     @Test
     void UUIDHolder가_NULL이면_리사이즈된_이미지로_예외를_던진다() {
         // Given
-        String destinationDirectory = MockFileData.TEST_DIRECTORY;
+        String targetDir = TEST_DIRECTORY;
         UUIDHolder uuidHolder = null;
         ResizedImage resizedImage = mock(ResizedImage.class);
-        when(resizedImage.getImageFormat()).thenReturn(MockFileData.TEST_EXTENSION);
+        when(resizedImage.getImageFormat()).thenReturn(TEST_EXTENSION);
         when(resizedImage.getSize()).thenReturn(MockFileData.FILE_SIZE);
 
         // When & Then
-        assertThatThrownBy(() -> FileMetaData.fromResizedImage(destinationDirectory, resizedImage, uuidHolder))
+        assertThatThrownBy(() -> FileMetaData.fromResizedImage(targetDir, resizedImage, uuidHolder))
                 .isInstanceOf(CustomFileExceptionHandler.class)
                 .hasMessageContaining(
                         ErrorCode.FILE_PROCESSING_ERROR.getMessage()
@@ -93,19 +97,14 @@ class FileMetaDataTest {
     @Test
     void MultipartFile로_파일_메타데이터를_생성한다() {
         // Given
-        String destinationDirectory = MockFileData.TEST_DIRECTORY;
-        MockMultipartFile multipartFile = new MockMultipartFile(
-                "file",
-                "original-file.jpeg",
-                "image/jpeg",
-                new byte[(int) MockFileData.FILE_SIZE]
-        );
+        String targetDir = TEST_DIRECTORY;
+        MockMultipartFile multipartFile = MockFileData.multipartFile;
 
         // When
         FileMetaData result = FileMetaData.fromMultipartFile(
-                destinationDirectory,
+                targetDir,
                 multipartFile,
-                () -> MockFileData.TEST_UUID
+                () -> TEST_UUID
         );
 
         // Then
@@ -113,25 +112,25 @@ class FileMetaDataTest {
         String extension = FilenameUtils.getExtension(multipartFile.getOriginalFilename());
 
         assertThat(result).isNotNull();
-        assertThat(result.getDirectory()).isEqualTo(destinationDirectory);
+        assertThat(result.getDirectory()).isEqualTo(targetDir);
         assertThat(result.getDetails()).isNotNull();
-        assertThat(result.getDetails().getName()).isEqualTo(MockFileData.TEST_FILE_NAME);
-        assertThat(result.getDetails().getContentType()).isEqualTo(MockFileData.TEST_CONTENT_TYPE);
+        assertThat(result.getDetails().getName()).isEqualTo(TEST_FILE_NAME);
+        assertThat(result.getDetails().getContentType()).isEqualTo(MockFileData.FILE_CONTENT_TYPE);
         assertThat(result.getDetails().getSize()).isEqualTo(MockFileData.FILE_SIZE);
 
         assertThat(originalFileName).isEqualTo(multipartFile.getOriginalFilename());
-        assertThat(extension).isEqualTo(MockFileData.TEST_EXTENSION);
+        assertThat(extension).isEqualTo(TEST_EXTENSION);
     }
 
     @Test
     void MultipartFile이_NULL이면_예외를_던진다() {
         // Given
-        String destinationDirectory = MockFileData.TEST_DIRECTORY;
-        UUIDHolder uuidHolder = () -> MockFileData.TEST_UUID;
+        String targetDir = TEST_DIRECTORY;
+        UUIDHolder uuidHolder = () -> TEST_UUID;
         MockMultipartFile invalidFile = null;
 
         // When & Then
-        assertThatThrownBy(() -> FileMetaData.fromMultipartFile(destinationDirectory, invalidFile, uuidHolder))
+        assertThatThrownBy(() -> FileMetaData.fromMultipartFile(targetDir, invalidFile, uuidHolder))
                 .isInstanceOf(CustomFileExceptionHandler.class)
                 .hasMessageContaining(
                         ErrorCode.FILE_PROCESSING_ERROR.getMessage()
@@ -139,23 +138,18 @@ class FileMetaDataTest {
     }
 
     @Test
-    void 저장_디렉토리가_NULL이면_MultipartFile로_예외를_던진다() {
+    void 저장_디렉토리가_NULL이면_MultiptargetDirartFile로_예외를_던진다() {
         // Given
-        String emptyDirectory = null;
-        MockMultipartFile multipartFile = new MockMultipartFile(
-                "file",
-                "original-file.jpeg",
-                "image/jpeg",
-                new byte[(int) MockFileData.FILE_SIZE]
-        );
-        UUIDHolder uuidHolder = () -> MockFileData.TEST_UUID;
+        String emptyDir = null;
+        MockMultipartFile multipartFile = MockFileData.multipartFile;
+        UUIDHolder uuidHolder = () -> TEST_UUID;
 
         ResizedImage resizedImage = mock(ResizedImage.class);
-        when(resizedImage.getImageFormat()).thenReturn(MockFileData.TEST_EXTENSION);
+        when(resizedImage.getImageFormat()).thenReturn(TEST_EXTENSION);
         when(resizedImage.getSize()).thenReturn(MockFileData.FILE_SIZE);
 
         // When & Then
-        assertThatThrownBy(() -> FileMetaData.fromMultipartFile(emptyDirectory, multipartFile, uuidHolder))
+        assertThatThrownBy(() -> FileMetaData.fromMultipartFile(emptyDir, multipartFile, uuidHolder))
                 .isInstanceOf(CustomFileExceptionHandler.class)
                 .hasMessageContaining(
                         ErrorCode.FILE_PROCESSING_ERROR.getMessage()
@@ -165,17 +159,12 @@ class FileMetaDataTest {
     @Test
     void UUIDHolder가_NULL_이면_MultipartFile로_예외를_던진다() {
         // Given
-        String emptyDirectory = MockFileData.TEST_DIRECTORY;
+        String emptyDir = TEST_DIRECTORY;
         UUIDHolder uuidHolder = null;
-        MockMultipartFile multipartFile = new MockMultipartFile(
-                "file",
-                "original-file.jpeg",
-                "image/jpeg",
-                new byte[(int) MockFileData.FILE_SIZE]
-        );
+        MockMultipartFile multipartFile = MockFileData.multipartFile;
 
         // When & Then
-        assertThatThrownBy(() -> FileMetaData.fromMultipartFile(emptyDirectory, multipartFile, uuidHolder))
+        assertThatThrownBy(() -> FileMetaData.fromMultipartFile(emptyDir, multipartFile, uuidHolder))
                 .isInstanceOf(CustomFileExceptionHandler.class)
                 .hasMessageContaining(
                         ErrorCode.FILE_PROCESSING_ERROR.getMessage()

--- a/src/test/java/com/realworld/feature/file/domain/FileTest.java
+++ b/src/test/java/com/realworld/feature/file/domain/FileTest.java
@@ -7,16 +7,17 @@ import com.realworld.feature.file.entity.FileDetails;
 import com.realworld.feature.file.mock.MockFileData;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 class FileTest {
+
+    private static final String TEST_URL = "https://example.com/test-image.jpg";
 
     @Test
     void 파일을_생성한다() {
         // Given
-        FileDetails details = MockFileData.details;
-        String testUrl = MockFileData.TEST_URL;
+        FileDetails details = MockFileData.fileDetails;
+        String testUrl = TEST_URL;
 
         // When
         File result = File.create(details, testUrl);
@@ -29,7 +30,7 @@ class FileTest {
     @Test
     void 파일을_생성할_때_상세_정보가_NULL이면_예외를_던진다() {
         // When & Then
-        assertThatThrownBy(() -> File.create(null, MockFileData.TEST_URL))
+        assertThatThrownBy(() -> File.create(null, TEST_URL))
                 .isInstanceOf(CustomFileExceptionHandler.class)
                 .hasMessageContaining(
                         ErrorCode.FILE_PROCESSING_ERROR.getMessage()
@@ -39,7 +40,7 @@ class FileTest {
     @Test
     void 파일을_생성할_때_URL이_NULL이면_예외를_던진다() {
         // When & Then
-        assertThatThrownBy(() -> File.create(MockFileData.details, null))
+        assertThatThrownBy(() -> File.create(MockFileData.fileDetails, null))
                 .isInstanceOf(CustomFileExceptionHandler.class)
                 .hasMessageContaining(
                         ErrorCode.FILE_PROCESSING_ERROR.getMessage()

--- a/src/test/java/com/realworld/feature/file/mock/MockFileData.java
+++ b/src/test/java/com/realworld/feature/file/mock/MockFileData.java
@@ -2,37 +2,34 @@ package com.realworld.feature.file.mock;
 
 import com.realworld.feature.file.entity.FileDetails;
 import com.realworld.feature.file.entity.FileMetaData;
-
-import java.io.File;
+import org.springframework.mock.web.MockMultipartFile;
 
 public class MockFileData {
 
-    public static final String TEMPORARY_DIRECTORY = "temporary";
-    public static final String TEST_DIRECTORY = "test";
-    public static final String TEST_URL = "https://example.com/file.jpg";
+    private static final String FILE_FORM_NAME = "file";
 
-    public static final String TEST_UUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
-    public static final char TEST_EXTENSION_SEPARATOR = '.';
-    public static final String TEST_EXTENSION = "jpeg";
-    public static final String TEST_CONTENT_TYPE = "image/jpeg";
+    public static final String FILE_NAME = "test-image.jpeg";
+    public static final String FILE_CONTENT_TYPE = "image/jpeg";
     public static final long FILE_SIZE = 10 * 1024 * 1024;
 
-    private static final String TEST_IMAGE_PATH = "src/test/resources/image/test-image.jpeg";
-    public static final String TEST_FILE_NAME = TEST_UUID + TEST_EXTENSION_SEPARATOR + TEST_EXTENSION;
+    public static MockMultipartFile multipartFile = new MockMultipartFile(
+            FILE_FORM_NAME,
+            FILE_NAME,
+            FILE_CONTENT_TYPE,
+            new byte[(int) FILE_SIZE]
+    );
 
-    public static final File testFile = new File(TEST_IMAGE_PATH);
-    public static final FileDetails details = FileDetails.of(
-            TEST_FILE_NAME,
-            TEST_CONTENT_TYPE,
-            testFile.length()
+    public static final FileDetails fileDetails = FileDetails.of(
+            FILE_NAME,
+            FILE_CONTENT_TYPE,
+            FILE_SIZE
     );
 
     public static FileMetaData create(String destinationDirectory) {
         return FileMetaData.builder()
                 .directory(destinationDirectory)
-                .details(details)
+                .details(fileDetails)
                 .build();
     }
 
 }
-

--- a/src/test/java/com/realworld/feature/file/mock/MockFileData.java
+++ b/src/test/java/com/realworld/feature/file/mock/MockFileData.java
@@ -4,32 +4,33 @@ import com.realworld.feature.file.entity.FileDetails;
 import com.realworld.feature.file.entity.FileMetaData;
 import org.springframework.mock.web.MockMultipartFile;
 
-public class MockFileData {
+import java.io.File;
 
-    private static final String FILE_FORM_NAME = "file";
+public class MockFileData {
 
     public static final String FILE_NAME = "test-image.jpeg";
     public static final String FILE_CONTENT_TYPE = "image/jpeg";
     public static final long FILE_SIZE = 10 * 1024 * 1024;
 
+    public static final File testFile = new File("src/test/resources/image/test-image.jpeg");
+    public static final FileDetails fileDetails = FileDetails.of(
+            FILE_NAME,
+            FILE_CONTENT_TYPE,
+            testFile.length()
+    );
+
+    public static FileMetaData create(String targetDir) {
+        return FileMetaData.builder()
+                .directory(targetDir)
+                .details(fileDetails)
+                .build();
+    }
+
     public static MockMultipartFile multipartFile = new MockMultipartFile(
-            FILE_FORM_NAME,
+            "file",
             FILE_NAME,
             FILE_CONTENT_TYPE,
             new byte[(int) FILE_SIZE]
     );
-
-    public static final FileDetails fileDetails = FileDetails.of(
-            FILE_NAME,
-            FILE_CONTENT_TYPE,
-            FILE_SIZE
-    );
-
-    public static FileMetaData create(String destinationDirectory) {
-        return FileMetaData.builder()
-                .directory(destinationDirectory)
-                .details(fileDetails)
-                .build();
-    }
 
 }

--- a/src/test/java/com/realworld/infrastructure/cloud/aws/AwsS3HandlerImplTest.java
+++ b/src/test/java/com/realworld/infrastructure/cloud/aws/AwsS3HandlerImplTest.java
@@ -6,6 +6,7 @@ import com.realworld.feature.file.entity.FileMetaData;
 import com.realworld.feature.file.mock.MockFileData;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -14,17 +15,21 @@ import java.io.*;
 import static org.assertj.core.api.Assertions.*;
 
 @Disabled(
-        "AWS S3 관련 테스트는 비용 발생 우려로 인해 현재는 비활성화합니다."
+        """
+        AWS S3 관련 테스트는 비용 발생 우려로 인해 비활성화되어 있습니다.
+        로컬 환경에서 테스트할 경우, application-local.yml을 기준으로 실행해야 합니다.
+        CI/CD 환경에서 활성화할 경우, application-dev.yml을 기준으로 변경 후 실행해야 합니다.
+        """
 )
 @Deprecated
 @ActiveProfiles("local")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class AwsS3HandlerImplTest {
 
-    private static final String TEST_IMAGE_PATH = "src/test/resources/test_image.jpg";
-    private static final File TEST_FILE = new File(TEST_IMAGE_PATH);
     private static final String TEST_DIRECTORY = "temporary";
-    private static final String TEST_BUCKET_NAME = "test-bucket";
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
 
     @Autowired
     private AwsS3Handler awsS3Handler;
@@ -33,7 +38,7 @@ class AwsS3HandlerImplTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        inputStream = new FileInputStream(TEST_FILE);
+        inputStream = new FileInputStream(MockFileData.testFile);
     }
 
     @AfterEach
@@ -44,7 +49,7 @@ class AwsS3HandlerImplTest {
     }
 
     private String getBucketPath(String directory) {
-        return TEST_BUCKET_NAME + "/" + directory;
+        return bucket + "/" + directory;
     }
 
     @Test
@@ -80,11 +85,11 @@ class AwsS3HandlerImplTest {
         String savedFileUrl = awsS3Handler.save(metaData, inputStream);
 
         // when
-        String result = awsS3Handler.move(savedFileUrl, TEST_DIRECTORY);
+        String result = awsS3Handler.move(savedFileUrl, "test");
 
         // then
         assertThat(result).isNotNull();
-        assertThat(awsS3Handler.isFileExist(getBucketPath(TEST_DIRECTORY), metaData.getDetails().getName())).isTrue();
+        assertThat(awsS3Handler.isFileExist(getBucketPath("test"), metaData.getDetails().getName())).isTrue();
     }
 
     @Test

--- a/src/test/java/com/realworld/infrastructure/cloud/aws/mock/testcontainers/AwsS3HandlerTestContainersTest.java
+++ b/src/test/java/com/realworld/infrastructure/cloud/aws/mock/testcontainers/AwsS3HandlerTestContainersTest.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.realworld.common.exception.custom.CustomFileExceptionHandler;
 import com.realworld.common.response.code.ErrorCode;
 import com.realworld.feature.file.entity.FileMetaData;
+import com.realworld.feature.file.mock.MockFileData;
 import com.realworld.infrastructure.cloud.aws.AwsS3Handler;
 import com.realworld.infrastructure.cloud.aws.AwsS3HandlerImpl;
 import org.junit.jupiter.api.*;
@@ -21,9 +22,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.io.*;
 
-import static com.realworld.feature.file.mock.MockFileData.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 @Testcontainers
 @ActiveProfiles("test")
@@ -31,25 +30,25 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class AwsS3HandlerTestContainersTest {
 
     private static final DockerImageName LOCALSTACK_IMAGE_NAME = DockerImageName.parse("localstack/localstack:latest");
+    private static final String TEST_IMAGE_PATH = "src/test/resources/test_image.jpg";
+    private static final File TEST_FILE = new File(TEST_IMAGE_PATH);
+    private static final String LOCALSTACK_URI = "http://localhost:4566/";
+    private static final String TEST_BUCKET_NAME = "test-bucket";
+    private static final String TEST_DIRECTORY = "temporary";
 
     @Container
     public static final LocalStackContainer localStack = new LocalStackContainer(LOCALSTACK_IMAGE_NAME)
-            .withServices(
-                    Service.S3
-            );
-
-    private static final String localFrontBaseUri = "http://localhost:4566/";
-
-    private static final String BUCKET_NAME = "photocardsite";
+            .withServices(Service.S3);
 
     private AmazonS3 s3Client;
-
     private AwsS3Handler awsS3Handler;
 
     private InputStream inputStream;
 
     @BeforeEach
     void setUp() throws IOException {
+        inputStream = new FileInputStream(TEST_FILE);
+
         s3Client = AmazonS3ClientBuilder
                 .standard()
                 .withEndpointConfiguration(
@@ -65,11 +64,9 @@ class AwsS3HandlerTestContainersTest {
                 )
                 .build();
 
-        s3Client.createBucket(BUCKET_NAME);
+        s3Client.createBucket(TEST_BUCKET_NAME);
 
-        awsS3Handler = new AwsS3HandlerImpl(localFrontBaseUri, BUCKET_NAME, s3Client);
-
-        inputStream = new FileInputStream(testFile);
+        awsS3Handler = new AwsS3HandlerImpl(LOCALSTACK_URI, TEST_BUCKET_NAME, s3Client);
     }
 
     @AfterEach
@@ -80,39 +77,39 @@ class AwsS3HandlerTestContainersTest {
     }
 
     private String getBucketPath(String directory) {
-        return BUCKET_NAME + "/" + directory;
+        return TEST_BUCKET_NAME + "/" + directory;
     }
 
     @Test
-    void AWS_S3_파일_업로드() {
+    void 파일을_S3에_업로드하면_정상적으로_업로드된_URL을_반환한다() {
         // given
-        FileMetaData metaData = create(TEMPORARY_DIRECTORY);
+        FileMetaData metaData = MockFileData.create(TEST_DIRECTORY);
 
         // when
         String result = awsS3Handler.save(metaData, inputStream);
 
         // then
         assertThat(result).isNotNull();
-        assertThat(awsS3Handler.isFileExist(getBucketPath(TEMPORARY_DIRECTORY), metaData.getDetails().getName())).isTrue();
+        assertThat(awsS3Handler.isFileExist(getBucketPath(TEST_DIRECTORY), metaData.getDetails().getName())).isTrue();
     }
 
     @Test
-    void AWS_S3_파일_조회() {
+    void S3에_업로드된_파일이_존재하는지_확인한다() {
         // given
-        FileMetaData metaData = create(TEMPORARY_DIRECTORY);
+        FileMetaData metaData = MockFileData.create(TEST_DIRECTORY);
         awsS3Handler.save(metaData, inputStream);
 
         // when
-        Boolean result = awsS3Handler.isFileExist(getBucketPath(TEMPORARY_DIRECTORY), metaData.getDetails().getName());
+        Boolean result = awsS3Handler.isFileExist(getBucketPath(TEST_DIRECTORY), metaData.getDetails().getName());
 
         // then
         assertThat(result).isTrue();
     }
 
     @Test
-    void AWS_S3_파일_이동() {
+    void S3_파일을_다른_디렉토리로_이동하면_정상적으로_이동된다() {
         // given
-        FileMetaData metaData = create(TEMPORARY_DIRECTORY);
+        FileMetaData metaData = MockFileData.create(TEST_DIRECTORY);
         String savedFileUrl = awsS3Handler.save(metaData, inputStream);
 
         // when
@@ -124,7 +121,7 @@ class AwsS3HandlerTestContainersTest {
     }
 
     @Test
-    void AWS_S3_존재하지_않는_파일_이동_시_예외_발생() {
+    void 존재하지_않는_S3_파일을_이동하려고_하면_예외를_발생시킨다() {
         //given
         String nonExistentFileUrl = "https://xxxxxxxxxxxxxx.cloudfront.net/test/test.jpeg";
 
@@ -137,20 +134,20 @@ class AwsS3HandlerTestContainersTest {
     }
 
     @Test
-    void AWS_S3_파일_삭제() {
+    void S3에서_파일을_삭제하면_정상적으로_삭제된다() {
         // given
-        FileMetaData metaData = create(TEMPORARY_DIRECTORY);
+        FileMetaData metaData = MockFileData.create(TEST_DIRECTORY);
         String savedFileUrl = awsS3Handler.save(metaData, inputStream);
 
         // when
         awsS3Handler.delete(savedFileUrl);
 
         // then
-        assertThat(awsS3Handler.isFileExist(getBucketPath(TEMPORARY_DIRECTORY), metaData.getDetails().getName())).isFalse();
+        assertThat(awsS3Handler.isFileExist(getBucketPath(TEST_DIRECTORY), metaData.getDetails().getName())).isFalse();
     }
 
     @Test
-    void AWS_S3_존재하지_않는_파일_삭제_시_예외_발생() {
+    void 존재하지_않는_S3_파일을_삭제하려고_하면_예외를_발생시킨다() {
         //given
         String nonExistentFileUrl = "https://xxxxxxxxxxxxxx.cloudfront.net/test/test.jpeg";
 


### PR DESCRIPTION
## ✨ 작업 내용
- 테스트 메서드 명명을 직관적이게 수정했습니다.
- 일관된 MockMultipartFile를 반환하는 정적 메서드 추가했습니다.

---

## 💡 변경 이유
- 테스트 실행에 있어 중요한 상태 보존에 관해서 집중적이게 메서드 명명을 수정했습니다.
- 보일러플레이트 감소를 위해 MockFileData에서 일관된 MockMultipartFile를 반환하는 것으로 수정했습니다.
